### PR TITLE
Update menu.json

### DIFF
--- a/menu.json
+++ b/menu.json
@@ -114,12 +114,12 @@
                 {
                     "allOfList": [
                         {
-                            "$type": "ORTS.NotContains, Menu",
+                            "$type": "ORTS.NotEquals, Menu",
                             "property": "{{installed_version}}",
                             "value": "{{latest_version}}"
                         },
                         {
-                            "$type": "ORTS.NotContains, Menu",
+                            "$type": "ORTS.NotEquals, Menu",
                             "property": "{{update_mode}}",
                             "value": "none"
                         }


### PR DESCRIPTION
This fixes the update from `1.6-rc8` to `1.6` not showing up correctly (because the installed version contains the latest version)