### PR TITLE
Removes Refresh button

### DIFF
--- a/menu.json
+++ b/menu.json
@@ -50,13 +50,6 @@
                     "testingUrl": "https://www.openrails.org/download/changes/",
                     "unstableUrl": "https://james-ross.co.uk/projects/or",
                     "label": "What was new"
-                },
-                {
-                    "$type": "ORTS.Refresh, Menu",
-                    "includeIf": ["update_mode_unstable"],
-                    "includeIfNot": ["ready_to_update"],
-                    "label": "Refresh",
-                    "value": "Refresh the 'Latest version available'"
                 }
             ]
         },


### PR DESCRIPTION
Temporary fix until we can find a way that works for everyone.

See [bug report](https://bugs.launchpad.net/or/+bug/2149851) and [forum thread](https://www.elvastower.com/forums/index.php?/topic/39609-notifications-are-not-available).
Required a code change (new class Refresh) which was available in Unstable and Testing but not in Stable (1.6.1)